### PR TITLE
Navigation with TAB should now work

### DIFF
--- a/mindmup-editabletable.js
+++ b/mindmup-editabletable.js
@@ -70,8 +70,15 @@ $.fn.editableTableWidget = function (options) {
 				editor.hide();
 				active.focus();
 			} else if (e.which === TAB) {
-				active.focus();
-			} else if (this.selectionEnd - this.selectionStart === this.value.length) {
+		            e.preventDefault();
+		            e.stopPropagation();
+		
+		            if (active.next('td').length == 0) {
+		                active.closest('tr').next().find('td:first-child').focus().click();
+		            } else {
+		                active.next('td').focus().click();
+		            }
+		        } else if (this.selectionEnd - this.selectionStart === this.value.length) {
 				var possibleMove = movement(active, e.which);
 				if (possibleMove.length > 0) {
 					possibleMove.focus();


### PR DESCRIPTION
When the focused cell reached the end of the row, the active.next('td').length returns 0.

By this trigger you can select the next row and the first column with this call:
  active.closest('tr').next().find('td:first-child').focus().click();
